### PR TITLE
Fix ConcurrentModificationException of ItemProperties#PROPERTIES caused by calling ItemProperties#register in the Client Setup phase

### DIFF
--- a/neoforge/src/main/java/ewewukek/musketmod/ClientSetup.java
+++ b/neoforge/src/main/java/ewewukek/musketmod/ClientSetup.java
@@ -29,7 +29,9 @@ public class ClientSetup {
     }
 
     public void setup(final FMLClientSetupEvent event) {
-        ClientUtilities.registerItemProperties();
+        event.enqueueWork(() -> {
+            ClientUtilities.registerItemProperties();
+        });
     }
 
     public void registerRenderers(final EntityRenderersEvent.RegisterRenderers event) {


### PR DESCRIPTION
Full crash info: [minecraft-exported-crash-info-2025-01-02T22-27-51(1).zip](https://github.com/user-attachments/files/18302339/minecraft-exported-crash-info-2025-01-02T22-27-51.1.zip)
I used [this project](https://github.com/Viola-Siemens/CME-Suck-My-Duck) to troubleshoot and found that your mod conflicts with avaritia and travelersbackpack. Please see CMESuckMyDuck.log for details.